### PR TITLE
Disabled scalac warnings for 'advanced' features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,9 @@
                     <configuration>
                         <scalaVersion>${scala.version}</scalaVersion>
                         <scalaCompatVersion>${scala.compat.version}</scalaCompatVersion>
+                        <args>
+                            <arg>-language:_</arg>
+                        </args>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
This will remove `scalac` warnings such as this:

`Warning:scalac: there were three feature warnings; re-run with -feature for details`

The canonical way is to include a line like this:

`import scala.language.implicitConversions`

for every single "advanced" Scala language feature used, _per file and per "advanced" Scala feature_.
But because we intend to use "advanced" Scala language features all over the place anyway, let's cut the code duplication and tell the compiler to skip those warnings.
