### PR TITLE
Kick-off for data analysis

### DIFF
--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/EventBridgeImpl.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/EventBridgeImpl.scala
@@ -1,13 +1,17 @@
 package de.metacoder.edwardthreadlocal
 
-/**
-  * Created by becker on 5/9/16.
-  */
+import de.metacoder.edwardthreadlocal.analysis.datamodel.CallData
+import de.metacoder.edwardthreadlocal.analysis.{AnalysisSetup, CallDataSink}
+
 class EventBridgeImpl extends EventBridge {
+  private implicit val setup:AnalysisSetup = AnalysisSetup.default
 
-  override def trackSet(affectedThreadLocal: ThreadLocal[_], valueToSet: scala.Any): Unit = println("I am the bridge impl trackSet")
-  override def activateTracingForThread(): Unit = println("I am the bridge impl activateTracingForThread")
-  override def deactivateTracingForThread(): Unit = println("I am the bridge impl deactivateTracingForThread")
-  override def trackRemove(affectedThreadLocal: ThreadLocal[_]): Unit = println("I am the bridge impl trackRemove")
-
+  override def activateTracingForThread() =
+    CallDataSink startRecordingSeries()
+  override def deactivateTracingForThread() =
+    CallDataSink endRecordingSeries()
+  override def trackRemove(affectedThreadLocal:ThreadLocal[_]) =
+    CallDataSink accept (CallData forCallToRemove affectedThreadLocal)
+  override def trackSet(affectedThreadLocal:ThreadLocal[_], valueToSet:Any) =
+    CallDataSink accept (CallData forCallToSet (affectedThreadLocal, valueToSet.asInstanceOf[AnyRef]))
 }

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/AnalysisSetup.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/AnalysisSetup.scala
@@ -1,0 +1,18 @@
+package de.metacoder.edwardthreadlocal.analysis
+
+import de.metacoder.edwardthreadlocal.analysis.datamodel.ValueInstanceID
+import de.metacoder.edwardthreadlocal.util.logging.{Log, MicroLogger}
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(msg="Make sure the AnalysisSetup instance is in the implicit context. It contains behavior that might be made configurable. In case of doubt, use `AnalysisSetup.default`.")
+trait AnalysisSetup {
+  def idOfValue(v:AnyRef):ValueInstanceID
+  def log:MicroLogger
+}
+object AnalysisSetup {
+  val default:AnalysisSetup = new AnalysisSetup {
+    def idOfValue(v:AnyRef) = ValueInstanceID.ByClassAndSystemIndentityHashCode of v
+    def log = Log.DEFAULT_LOGGER
+  }
+}

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSeriesSink.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSeriesSink.scala
@@ -1,0 +1,53 @@
+package de.metacoder.edwardthreadlocal.analysis
+
+import java.util.concurrent.atomic.AtomicLong
+
+import de.metacoder.edwardthreadlocal.analysis.datamodel.CallData.{CallToRemove, CallToSet, CurrentValueInfo}
+import de.metacoder.edwardthreadlocal.analysis.datamodel.{CallData, ValueInstanceID}
+
+import scala.annotation.tailrec
+
+object CallDataSeriesSink {
+  def accept(series:Seq[CallData])(implicit setup:AnalysisSetup):Unit = {
+    val serNum = newSeriesNumber()
+    postProcessedSeriesPerThreadLocal(series) foreach {case (tl,s)⇒
+      if(looksFaulty(s)) FaultyCallDataSeriesSink.accept(s, tl, serNum)
+    }
+  }
+
+  private def postProcessedSeriesPerThreadLocal(series:Seq[CallData]):Map[ThreadLocal[_],Seq[CallData]] =
+    series groupBy {_ threadLocal} mapValues postProcessedSeriesForOneThreadLocal filterNot {_._2 isEmpty}
+  private def postProcessedSeriesForOneThreadLocal(series:Seq[CallData]):Seq[CallData] = {
+    def isInterestingConsecutivePair(before:CallData, after:CallData, isLastPair:Boolean) =
+      if(before.threadLocal != after.threadLocal) true
+      else (before,after) match {
+        case (_:CallToRemove, CurrentValueInfo(_,nullInstanceID)) if nullInstanceID.refersToNull && !isLastPair ⇒ false
+        case (CurrentValueInfo(_,same1), CurrentValueInfo(_,same2)) if same1==same2 ⇒ false
+        case (CallToSet(_,same1,_), CurrentValueInfo(_,same2)) if same1==same2 && !isLastPair ⇒ false
+        case (CallToSet(_,same1,_), CallToSet(_,same2,_)) if same1==same2 ⇒ false
+        case _ ⇒ true
+      }
+    def withoutBoringSubSequences(series:Seq[CallData]):Seq[CallData] = series match {
+      case Seq() | Seq(_) ⇒ series
+      case Seq(fst,snd,rst@_*) ⇒
+        if(!isInterestingConsecutivePair(fst,snd,rst isEmpty)) withoutBoringSubSequences(fst+:rst)
+        else fst+:withoutBoringSubSequences(snd+:rst)
+    }
+    withoutBoringSubSequences(series)
+  }
+
+  private def looksFaulty(series:Seq[CallData]):Boolean = {
+    @tailrec def recurse(s:Seq[CallData],initialValue:Option[ValueInstanceID],lastSeenValue:Option[ValueInstanceID]):Boolean = s match {
+      case Seq() ⇒ initialValue!=lastSeenValue
+      case Seq(CurrentValueInfo(_,cv),rst@_*) if initialValue isEmpty ⇒ recurse(s, Some(cv), lastSeenValue)
+      case Seq(CurrentValueInfo(_,cv),rst@_*) ⇒ recurse(rst, initialValue, Some(cv))
+      case Seq(CallToSet(_,cv,_),rst@_*) if initialValue isEmpty ⇒ recurse(s, Some(cv), lastSeenValue)
+      case Seq(CallToSet(_,cv,_),rst@_*) ⇒ recurse(rst, initialValue, Some(cv))
+      case Seq(_:CallToRemove,rst@_*) ⇒ recurse(rst, initialValue, None)
+      case Seq(_,rst@_*) ⇒ recurse(rst, initialValue, lastSeenValue)
+    }
+    recurse(series, None, None)
+  }
+
+  private val newSeriesNumber:()⇒Long = {val nextNumber=new AtomicLong; ()⇒nextNumber getAndIncrement()}
+}

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSink.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSink.scala
@@ -1,0 +1,47 @@
+package de.metacoder.edwardthreadlocal.analysis
+
+import de.metacoder.edwardthreadlocal.analysis.datamodel.CallData
+
+object CallDataSink {
+  def accept(cd:CallData)(implicit setup:AnalysisSetup):Unit =
+    currentSeriesOpt filter {_ recordingEnabled} foreach {series ⇒ storeCurrentSeries(series ++ withCurrentValueInfoBefore(cd))}
+  private def withCurrentValueInfoBefore(cd:CallData)(implicit setup:AnalysisSetup):Seq[CallData] =
+    Seq(CallData.forCurrentValueInfo(cd.threadLocal, offTheRecord {cd.threadLocal.get().asInstanceOf[AnyRef]}),cd)
+
+  def startRecordingSeries():Unit = currentSeriesOpt match {
+    case None ⇒ storeCurrentSeries(emptySeries)
+    case Some(disabled) if !disabled.recordingEnabled ⇒ storeCurrentSeries(disabled withRecordingEnabled true)
+    case anythingElse ⇒ ()
+  }
+
+  def endRecordingSeries()(implicit setup:AnalysisSetup):Unit = currentSeriesOpt foreach {series ⇒
+    CallDataSeriesSink accept withAllCurrentValuesBehind(series recordedData)
+    removeCurrentSeries()
+  }
+  private def withAllCurrentValuesBehind(seriesData:Seq[CallData])(implicit setup:AnalysisSetup):Seq[CallData] =
+    seriesData ++
+      ((seriesData map {_ threadLocal} distinct) map {tl⇒offTheRecord(CallData.forCurrentValueInfo(tl, tl.get.asInstanceOf[AnyRef]))})
+
+  private case class Series(recordingEnabled:Boolean, recordedData:Seq[CallData]) {
+    def +(cd:CallData):Series = copy(recordedData=recordedData:+cd)
+    def ++(cds:Iterable[CallData]):Series = cds.foldLeft(this) {_ + _}
+    def withRecordingEnabled(enabled:Boolean):Series = copy(recordingEnabled=enabled)
+  }
+  private val emptySeries = Series(recordingEnabled=true, recordedData=Seq())
+
+  private var currentSeries:Map[Thread,Series] = Map()
+  private val currentSeriesMutex = new AnyRef
+  private def inMutex[T](f: ⇒T):T = currentSeriesMutex synchronized f
+
+  private def currentSeriesOpt:Option[Series] = inMutex {currentSeries.get(Thread currentThread)}
+  private def storeCurrentSeries(series:Series) = inMutex {currentSeries = currentSeries+(Thread.currentThread→series)}
+  private def removeCurrentSeries() = inMutex {currentSeries = currentSeries-Thread.currentThread}
+
+  private def offTheRecord[T](doWhat: ⇒T):T = {
+    val seriesBefore = currentSeriesOpt
+    seriesBefore foreach {f⇒storeCurrentSeries(f withRecordingEnabled false)}
+    val result:T = doWhat
+    seriesBefore foreach storeCurrentSeries
+    result
+  }
+}

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/FaultyCallDataSeriesSink.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/FaultyCallDataSeriesSink.scala
@@ -1,0 +1,27 @@
+package de.metacoder.edwardthreadlocal.analysis
+
+import de.metacoder.edwardthreadlocal.analysis.datamodel.CallData.{CallToRemove, CallToSet, CurrentValueInfo}
+import de.metacoder.edwardthreadlocal.analysis.datamodel.{CallData, StackTrace}
+
+object FaultyCallDataSeriesSink {
+  def accept(series:Seq[CallData], threadLocal:ThreadLocal[_], seriesNumber:Long)(implicit setup:AnalysisSetup) {
+    import setup.log
+    log.warn(s"Possibly faulty series recognized, for $threadLocal, in series no. $seriesNumber:")
+    var instructionCounter = 0
+    def warn(msg:String) = log warn s"#$seriesNumber/$threadLocal[$instructionCounter] $msg"
+    def warnStackTrace(st:StackTrace) {st.elements foreach {element⇒warn(s"  at $element")}}
+    series foreach {
+      case CallToRemove(_,stackTrace) ⇒
+        warn("ThreadLocal.remove()")
+        warnStackTrace(stackTrace)
+        instructionCounter += 1
+      case CallToSet(_,value,stackTrace) ⇒
+        warn(s"ThreadLocal.set($value)")
+        warnStackTrace(stackTrace)
+        instructionCounter += 1
+      case CurrentValueInfo(_,value) ⇒
+        warn(s"Value is now: $value")
+        instructionCounter += 1
+    }
+  }
+}

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/CallData.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/CallData.scala
@@ -1,0 +1,19 @@
+package de.metacoder.edwardthreadlocal.analysis.datamodel
+
+import de.metacoder.edwardthreadlocal.analysis.AnalysisSetup
+
+sealed trait CallData {def threadLocal:ThreadLocal[_]}
+object CallData {
+  def forCallToRemove(tl:ThreadLocal[_]):CallToRemove =
+    CallToRemove(tl, StackTrace.current())
+  def forCallToSet(tl:ThreadLocal[_], newValue:AnyRef)(implicit setup:AnalysisSetup):CallToSet =
+    CallToSet(tl, setup idOfValue newValue, StackTrace.current())
+  def forCurrentValueInfo(tl:ThreadLocal[_], currentValue:AnyRef)(implicit setup:AnalysisSetup):CurrentValueInfo =
+    CurrentValueInfo(tl, setup idOfValue currentValue)
+
+  sealed trait WithStackTrace extends CallData {def stackTrace:StackTrace}
+
+  sealed case class CallToRemove(threadLocal:ThreadLocal[_], stackTrace:StackTrace) extends WithStackTrace
+  sealed case class CallToSet(threadLocal:ThreadLocal[_], valueID:ValueInstanceID, stackTrace:StackTrace) extends WithStackTrace
+  sealed case class CurrentValueInfo(threadLocal:ThreadLocal[_], currentValueID:ValueInstanceID) extends CallData
+}

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/StackTrace.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/StackTrace.scala
@@ -1,0 +1,28 @@
+package de.metacoder.edwardthreadlocal.analysis.datamodel
+
+import de.metacoder.edwardthreadlocal
+
+// other than a StackTraceElement array, this can be compared with equals, and returns a meaningful toString
+case class StackTrace(elements:Seq[StackTraceElement])
+object StackTrace {
+  private val trivialStackLocalMethodNames = Set("set", "remove")
+  def current():StackTrace = {
+    def removeInitialStackTraceCall(st:Seq[StackTraceElement]):Seq[StackTraceElement] = st match {
+      case Seq(getStackTraceCall,rst@_*) if getStackTraceCall.getClassName==classOf[Thread].getName ⇒ rst
+      case _ ⇒ st
+    }
+    def removeInitialEdwardThreadLocalCalls(st:Seq[StackTraceElement]):Seq[StackTraceElement] = st match {
+      case Seq(edwardThreadLocalCall,rst@_*) if edwardThreadLocalCall.getClassName.startsWith(edwardthreadlocal.packageName) ⇒
+        removeInitialEdwardThreadLocalCalls(rst)
+      case _ ⇒ st
+    }
+    def removeInitialTrivialThreadLocalCalls(st:Seq[StackTraceElement]):Seq[StackTraceElement] = st match {
+      case Seq(tlCall,rst@_*) if tlCall.getClassName==classOf[ThreadLocal[_]].getName && trivialStackLocalMethodNames(tlCall getMethodName) ⇒
+        removeInitialTrivialThreadLocalCalls(rst)
+      case _ ⇒ st
+    }
+    val removeReduntantIntials:Seq[StackTraceElement]⇒Seq[StackTraceElement] =
+      removeInitialStackTraceCall _ andThen removeInitialEdwardThreadLocalCalls andThen removeInitialTrivialThreadLocalCalls
+    StackTrace(removeReduntantIntials(Thread.currentThread().getStackTrace toSeq))
+  }
+}

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/ValueInstanceID.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/ValueInstanceID.scala
@@ -1,0 +1,21 @@
+package de.metacoder.edwardthreadlocal.analysis.datamodel
+
+import de.metacoder.edwardthreadlocal.analysis.AnalysisSetup
+
+sealed trait ValueInstanceID {
+  def refersToNull:Boolean
+}
+object ValueInstanceID {
+  def of(value:AnyRef)(implicit setup:AnalysisSetup):ValueInstanceID = setup idOfValue value
+
+  private[analysis] sealed case class ByClassAndSystemIndentityHashCode(clazz:Class[_], systemIdentityHashCode:Int) extends ValueInstanceID {
+    def refersToNull = clazz==null
+    override def toString = if(refersToNull) "null" else s"${clazz getName}@$systemIdentityHashCode"
+  }
+  private[analysis] object ByClassAndSystemIndentityHashCode {
+    def of(v:AnyRef) = v match {
+      case null ⇒ ByClassAndSystemIndentityHashCode(null, 0)
+      case notNull ⇒ ByClassAndSystemIndentityHashCode(v getClass, System identityHashCode v)
+    }
+  }
+}

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/package.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/package.scala
@@ -1,0 +1,5 @@
+package de.metacoder
+
+package object edwardthreadlocal {
+  val packageName = getClass.getPackage.getName
+}

--- a/agent-test/src/main/java/de/metacoder/edwardthreadlocal/test/Main.java
+++ b/agent-test/src/main/java/de/metacoder/edwardthreadlocal/test/Main.java
@@ -21,6 +21,8 @@ public class Main {
         System.out.println("removing the thread local value");
         tl.remove();
         System.out.println("Removed =)");
+        tl.set("now this is bad");
+        System.out.println("Intentionally set another value, which should be registered as faulty");
       }
     } finally {
       afterBL();


### PR DESCRIPTION
This implements the basic functionality that we want to have:
It reports series of calls to `ThreadLocal` methods that look "faulty".

"Faulty" in this case means: At the end of the call sequence, the value is not the same as in the beginning.

This is just a kick-off though, as some further things are missing, namely:
- Instead of reporting immediately, gather info and report in the end. (How will the end report be triggered?)
- Instead of reporting similar call sequences, compare them and just increment a counter for similar ones.
- Unit tests!
