### PR TITLE
Enabled detailed Scala feature warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,9 @@
                     <configuration>
                         <scalaVersion>${scala.version}</scalaVersion>
                         <scalaCompatVersion>${scala.compat.version}</scalaCompatVersion>
+                        <args>
+                            <arg>-feature</arg>
+                        </args>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
As discussed face-to-face, we agreed to keep the Scala feature warnings visible.

Therefore, this PR enables detailed feature warnings during the compilation process, including file names and line numbers of the warnings.
This gives more visibility to those warnings, and makes it easier to fix them, using tool support.
