### PR TITLE
Fixed all current Scala feature warnings

### DIFF
--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSink.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSink.scala
@@ -1,5 +1,7 @@
 package de.metacoder.edwardthreadlocal.analysis
 
+import scala.language.postfixOps
+
 import de.metacoder.edwardthreadlocal.analysis.datamodel.CallData
 
 object CallDataSink {

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/CallData.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/CallData.scala
@@ -6,14 +6,14 @@ sealed trait CallData {
   def threadLocal:ThreadLocal[_]
 }
 object CallData {
-  def forCallToRemove(tl:ThreadLocal[_]):CallToRemove =
+  def forCallToRemove[A](tl:ThreadLocal[A]):CallToRemove[A] =
     CallToRemove(tl, StackTrace.current())
-  def forCallToSet(tl:ThreadLocal[_], newValue:AnyRef)(implicit setup:AnalysisSetup):CallToSet =
+  def forCallToSet[A](tl:ThreadLocal[A], newValue:AnyRef)(implicit setup:AnalysisSetup):CallToSet[A] =
     CallToSet(tl, setup idOfValue newValue, StackTrace.current())
-  def forCurrentValueInfo(tl:ThreadLocal[_], currentValue:AnyRef)(implicit setup:AnalysisSetup):CurrentValueInfo =
+  def forCurrentValueInfo[A](tl:ThreadLocal[A], currentValue:AnyRef)(implicit setup:AnalysisSetup):CurrentValueInfo[A] =
     CurrentValueInfo(tl, setup idOfValue currentValue)
 
-  sealed case class CallToRemove(threadLocal:ThreadLocal[_], stackTrace:StackTrace) extends CallData
-  sealed case class CallToSet(threadLocal:ThreadLocal[_], valueID:ValueInstanceID, stackTrace:StackTrace) extends CallData
-  sealed case class CurrentValueInfo(threadLocal:ThreadLocal[_], currentValueID:ValueInstanceID) extends CallData
+  sealed case class CallToRemove[A](threadLocal:ThreadLocal[A], stackTrace:StackTrace) extends CallData
+  sealed case class CallToSet[A](threadLocal:ThreadLocal[A], valueID:ValueInstanceID, stackTrace:StackTrace) extends CallData
+  sealed case class CurrentValueInfo[A](threadLocal:ThreadLocal[A], currentValueID:ValueInstanceID) extends CallData
 }

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/StackTrace.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/StackTrace.scala
@@ -2,6 +2,8 @@ package de.metacoder.edwardthreadlocal.analysis.datamodel
 
 import de.metacoder.edwardthreadlocal
 
+import scala.language.postfixOps
+
 // other than a StackTraceElement array, this can be compared with equals, and returns a meaningful toString
 case class StackTrace(elements:Seq[StackTraceElement])
 object StackTrace {
@@ -17,7 +19,7 @@ object StackTrace {
       case _ ⇒ st
     }
     def removeInitialTrivialThreadLocalCalls(st:Seq[StackTraceElement]):Seq[StackTraceElement] = st match {
-      case Seq(tlCall, rst@_*) if tlCall.getClassName == classOf[ThreadLocal[_]].getName && trivialStackLocalMethodNames(tlCall getMethodName) ⇒
+      case Seq(tlCall, rst@_*) if tlCall.getClassName == classOf[ThreadLocal[_]].getName && trivialStackLocalMethodNames(tlCall.getMethodName) ⇒
         removeInitialTrivialThreadLocalCalls(rst)
       case _ ⇒ st
     }

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/ValueInstanceID.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/ValueInstanceID.scala
@@ -8,14 +8,14 @@ sealed trait ValueInstanceID {
 object ValueInstanceID {
   def of(value:AnyRef)(implicit setup:AnalysisSetup):ValueInstanceID = setup idOfValue value
 
-  private[analysis] sealed case class ByClassAndSystemIndentityHashCode(clazz:Class[_], systemIdentityHashCode:Int) extends ValueInstanceID {
+  private[analysis] sealed case class ByClassAndSystemIndentityHashCode[A](clazz:Class[A], systemIdentityHashCode:Int) extends ValueInstanceID {
     def refersToNull = clazz == null
-    override def toString = if (refersToNull) "null" else s"${clazz getName}@$systemIdentityHashCode"
+    override def toString = if (refersToNull) "null" else s"${clazz.getName}@$systemIdentityHashCode"
   }
   private[analysis] object ByClassAndSystemIndentityHashCode {
     def of(v:AnyRef) = v match {
       case null ⇒ ByClassAndSystemIndentityHashCode(null, 0)
-      case notNull ⇒ ByClassAndSystemIndentityHashCode(v getClass, System identityHashCode v)
+      case notNull ⇒ ByClassAndSystemIndentityHashCode(v.getClass, System.identityHashCode(v))
     }
   }
 }

--- a/intellij-code-style.xml
+++ b/intellij-code-style.xml
@@ -1,8 +1,28 @@
 <code_scheme name="Metacoder">
+  <JavaCodeStyleSettings>
+    <option name="BLANK_LINES_AROUND_INITIALIZER" value="0" />
+  </JavaCodeStyleSettings>
+  <ScalaCodeStyleSettings>
+    <option name="SPACE_INSIDE_CLOSURE_BRACES" value="false" />
+    <option name="ALTERNATE_CONTINUATION_INDENT_FOR_PARAMS" value="2" />
+    <option name="SPACE_AFTER_TYPE_COLON" value="false" />
+    <option name="SD_ALIGN_OTHER_TAGS_COMMENTS" value="false" />
+    <option name="SD_ALIGN_PARAMETERS_COMMENTS" value="false" />
+    <option name="SD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+    <option name="SD_ALIGN_RETURN_COMMENTS" value="false" />
+    <option name="SD_BLANK_LINE_BEFORE_TAGS" value="false" />
+    <option name="SD_KEEP_BLANK_LINES_BETWEEN_TAGS" value="true" />
+    <option name="ENFORCE_FUNCTIONAL_SYNTAX_FOR_UNIT" value="false" />
+    <option name="REPLACE_CASE_ARROW_WITH_UNICODE_CHAR" value="true" />
+    <option name="REPLACE_MAP_ARROW_WITH_UNICODE_CHAR" value="true" />
+    <option name="REPLACE_FOR_GENERATOR_ARROW_WITH_UNICODE_CHAR" value="true" />
+  </ScalaCodeStyleSettings>
   <XML>
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
   </XML>
   <codeStyleSettings language="JAVA">
+    <option name="BLANK_LINES_AROUND_METHOD" value="0" />
+    <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
     <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
     <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
     <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
@@ -15,5 +35,11 @@
       <option name="CONTINUATION_INDENT_SIZE" value="2" />
       <option name="TAB_SIZE" value="2" />
     </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="Scala">
+    <option name="KEEP_FIRST_COLUMN_COMMENT" value="true" />
+    <option name="BLANK_LINES_AROUND_CLASS" value="0" />
+    <option name="BLANK_LINES_AROUND_METHOD" value="0" />
+    <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
   </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
This will fix _all_ of the current Scala feature warnings during the compile process.

Sometimes, this is achieved by using the specific `import` from `scala.language....`.
But I followed the spirit of our recent meeting, and fixed some Scala feature warnings by changing the code itself.
