### PR TITLE
Enabled auto-formatting for Agent-Impl Scala files

### DIFF
--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/EventBridgeImpl.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/EventBridgeImpl.scala
@@ -6,12 +6,13 @@ import de.metacoder.edwardthreadlocal.analysis.{AnalysisSetup, CallDataSink}
 class EventBridgeImpl extends EventBridge {
   private implicit val setup:AnalysisSetup = AnalysisSetup.default
 
-  override def activateTracingForThread() =
-    CallDataSink startRecordingSeries()
-  override def deactivateTracingForThread() =
-    CallDataSink endRecordingSeries()
+  override def activateTracingForThread() = CallDataSink startRecordingSeries()
+
+  override def deactivateTracingForThread() = CallDataSink endRecordingSeries()
+
   override def trackRemove(affectedThreadLocal:ThreadLocal[_]) =
     CallDataSink accept (CallData forCallToRemove affectedThreadLocal)
+  
   override def trackSet(affectedThreadLocal:ThreadLocal[_], valueToSet:Any) =
-    CallDataSink accept (CallData forCallToSet (affectedThreadLocal, valueToSet.asInstanceOf[AnyRef]))
+    CallDataSink accept (CallData forCallToSet(affectedThreadLocal, valueToSet.asInstanceOf[AnyRef]))
 }

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/AnalysisSetup.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/AnalysisSetup.scala
@@ -5,7 +5,7 @@ import de.metacoder.edwardthreadlocal.util.logging.{Log, MicroLogger}
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound(msg="Make sure the AnalysisSetup instance is in the implicit context. It contains behavior that might be made configurable. In case of doubt, use `AnalysisSetup.default`.")
+@implicitNotFound(msg = "Make sure the AnalysisSetup instance is in the implicit context. It contains behavior that might be made configurable. In case of doubt, use `AnalysisSetup.default`.")
 trait AnalysisSetup {
   def idOfValue(v:AnyRef):ValueInstanceID
   def log:MicroLogger

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSeriesSink.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSeriesSink.scala
@@ -8,46 +8,49 @@ import de.metacoder.edwardthreadlocal.analysis.datamodel.{CallData, ValueInstanc
 import scala.annotation.tailrec
 
 object CallDataSeriesSink {
-  def accept(series:Seq[CallData])(implicit setup:AnalysisSetup):Unit = {
+  def accept(series:Seq[CallData])(implicit setup:AnalysisSetup) {
     val serNum = newSeriesNumber()
-    postProcessedSeriesPerThreadLocal(series) foreach {case (tl,s)⇒
-      if(looksFaulty(s)) FaultyCallDataSeriesSink.accept(s, tl, serNum)
+    postProcessedSeriesPerThreadLocal(series).filter(e ⇒ looksFaulty(e._2)) foreach {case (tl, s) ⇒
+      FaultyCallDataSeriesSink.accept(s, tl, serNum)
     }
   }
 
-  private def postProcessedSeriesPerThreadLocal(series:Seq[CallData]):Map[ThreadLocal[_],Seq[CallData]] =
-    series groupBy {_ threadLocal} mapValues postProcessedSeriesForOneThreadLocal filterNot {_._2 isEmpty}
+  private def postProcessedSeriesPerThreadLocal(series:Seq[CallData]):Map[ThreadLocal[_], Seq[CallData]] =
+    series groupBy (_ threadLocal) mapValues postProcessedSeriesForOneThreadLocal filterNot (_._2 isEmpty)
   private def postProcessedSeriesForOneThreadLocal(series:Seq[CallData]):Seq[CallData] = {
     def isInterestingConsecutivePair(before:CallData, after:CallData, isLastPair:Boolean) =
-      if(before.threadLocal != after.threadLocal) true
-      else (before,after) match {
-        case (_:CallToRemove, CurrentValueInfo(_,nullInstanceID)) if nullInstanceID.refersToNull && !isLastPair ⇒ false
-        case (CurrentValueInfo(_,same1), CurrentValueInfo(_,same2)) if same1==same2 ⇒ false
-        case (CallToSet(_,same1,_), CurrentValueInfo(_,same2)) if same1==same2 && !isLastPair ⇒ false
-        case (CallToSet(_,same1,_), CallToSet(_,same2,_)) if same1==same2 ⇒ false
+      if (before.threadLocal != after.threadLocal) true
+      else (before, after) match {
+        case (_:CallToRemove, CurrentValueInfo(_, nullInstanceID)) if nullInstanceID.refersToNull && !isLastPair ⇒ false
+        case (CurrentValueInfo(_, same1), CurrentValueInfo(_, same2)) if same1 == same2 ⇒ false
+        case (CallToSet(_, same1, _), CurrentValueInfo(_, same2)) if same1 == same2 && !isLastPair ⇒ false
+        case (CallToSet(_, same1, _), CallToSet(_, same2, _)) if same1 == same2 ⇒ false
         case _ ⇒ true
       }
     def withoutBoringSubSequences(series:Seq[CallData]):Seq[CallData] = series match {
       case Seq() | Seq(_) ⇒ series
-      case Seq(fst,snd,rst@_*) ⇒
-        if(!isInterestingConsecutivePair(fst,snd,rst isEmpty)) withoutBoringSubSequences(fst+:rst)
-        else fst+:withoutBoringSubSequences(snd+:rst)
+      case Seq(fst, snd, rst@_*) ⇒
+        if (!isInterestingConsecutivePair(fst, snd, rst isEmpty)) withoutBoringSubSequences(fst +: rst)
+        else fst +: withoutBoringSubSequences(snd +: rst)
     }
     withoutBoringSubSequences(series)
   }
 
   private def looksFaulty(series:Seq[CallData]):Boolean = {
-    @tailrec def recurse(s:Seq[CallData],initialValue:Option[ValueInstanceID],lastSeenValue:Option[ValueInstanceID]):Boolean = s match {
-      case Seq() ⇒ initialValue!=lastSeenValue
-      case Seq(CurrentValueInfo(_,cv),rst@_*) if initialValue isEmpty ⇒ recurse(s, Some(cv), lastSeenValue)
-      case Seq(CurrentValueInfo(_,cv),rst@_*) ⇒ recurse(rst, initialValue, Some(cv))
-      case Seq(CallToSet(_,cv,_),rst@_*) if initialValue isEmpty ⇒ recurse(s, Some(cv), lastSeenValue)
-      case Seq(CallToSet(_,cv,_),rst@_*) ⇒ recurse(rst, initialValue, Some(cv))
-      case Seq(_:CallToRemove,rst@_*) ⇒ recurse(rst, initialValue, None)
-      case Seq(_,rst@_*) ⇒ recurse(rst, initialValue, lastSeenValue)
+    @tailrec def recurse(s:Seq[CallData], initialValue:Option[ValueInstanceID], lastSeenValue:Option[ValueInstanceID]):Boolean = s match {
+      case Seq() ⇒ initialValue != lastSeenValue
+      case Seq(CurrentValueInfo(_, cv), rst@_*) if initialValue isEmpty ⇒ recurse(s, Some(cv), lastSeenValue)
+      case Seq(CurrentValueInfo(_, cv), rst@_*) ⇒ recurse(rst, initialValue, Some(cv))
+      case Seq(CallToSet(_, cv, _), rst@_*) if initialValue isEmpty ⇒ recurse(s, Some(cv), lastSeenValue)
+      case Seq(CallToSet(_, cv, _), rst@_*) ⇒ recurse(rst, initialValue, Some(cv))
+      case Seq(_:CallToRemove, rst@_*) ⇒ recurse(rst, initialValue, None)
+      case Seq(_, rst@_*) ⇒ recurse(rst, initialValue, lastSeenValue)
     }
     recurse(series, None, None)
   }
 
-  private val newSeriesNumber:()⇒Long = {val nextNumber=new AtomicLong; ()⇒nextNumber getAndIncrement()}
+  private val newSeriesNumber:() ⇒ Long = {
+    val nextNumber = new AtomicLong
+    () ⇒ nextNumber getAndIncrement()
+  }
 }

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSink.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/CallDataSink.scala
@@ -4,9 +4,12 @@ import de.metacoder.edwardthreadlocal.analysis.datamodel.CallData
 
 object CallDataSink {
   def accept(cd:CallData)(implicit setup:AnalysisSetup):Unit =
-    currentSeriesOpt filter {_ recordingEnabled} foreach {series ⇒ storeCurrentSeries(series ++ withCurrentValueInfoBefore(cd))}
-  private def withCurrentValueInfoBefore(cd:CallData)(implicit setup:AnalysisSetup):Seq[CallData] =
-    Seq(CallData.forCurrentValueInfo(cd.threadLocal, offTheRecord {cd.threadLocal.get().asInstanceOf[AnyRef]}),cd)
+    currentSeriesOpt filter (_ recordingEnabled) foreach {series ⇒
+      storeCurrentSeries(series + currentValueInfoFor(cd threadLocal) + cd)
+    }
+
+  private def currentValueInfoFor(tl:ThreadLocal[_])(implicit setup:AnalysisSetup) =
+    CallData.forCurrentValueInfo(tl, offTheRecord(tl.get().asInstanceOf[AnyRef]))
 
   def startRecordingSeries():Unit = currentSeriesOpt match {
     case None ⇒ storeCurrentSeries(emptySeries)
@@ -19,27 +22,30 @@ object CallDataSink {
     removeCurrentSeries()
   }
   private def withAllCurrentValuesBehind(seriesData:Seq[CallData])(implicit setup:AnalysisSetup):Seq[CallData] =
-    seriesData ++
-      ((seriesData map {_ threadLocal} distinct) map {tl⇒offTheRecord(CallData.forCurrentValueInfo(tl, tl.get.asInstanceOf[AnyRef]))})
+    seriesData ++ ((seriesData map (_ threadLocal) distinct) map {tl ⇒ currentValueInfoFor(tl)})
 
   private case class Series(recordingEnabled:Boolean, recordedData:Seq[CallData]) {
-    def +(cd:CallData):Series = copy(recordedData=recordedData:+cd)
-    def ++(cds:Iterable[CallData]):Series = cds.foldLeft(this) {_ + _}
-    def withRecordingEnabled(enabled:Boolean):Series = copy(recordingEnabled=enabled)
+    def +(cd:CallData):Series = copy(recordedData = recordedData :+ cd)
+    def ++(cds:Iterable[CallData]):Series = cds.foldLeft(this)(_ + _)
+    def withRecordingEnabled(enabled:Boolean):Series = copy(recordingEnabled = enabled)
   }
-  private val emptySeries = Series(recordingEnabled=true, recordedData=Seq())
 
-  private var currentSeries:Map[Thread,Series] = Map()
+  private val emptySeries = Series(recordingEnabled = true, recordedData = Seq())
+
+  private var currentSeries:Map[Thread, Series] = Map()
   private val currentSeriesMutex = new AnyRef
-  private def inMutex[T](f: ⇒T):T = currentSeriesMutex synchronized f
+  private def inMutex[T](f: ⇒ T):T = currentSeriesMutex synchronized f
 
-  private def currentSeriesOpt:Option[Series] = inMutex {currentSeries.get(Thread currentThread)}
-  private def storeCurrentSeries(series:Series) = inMutex {currentSeries = currentSeries+(Thread.currentThread→series)}
-  private def removeCurrentSeries() = inMutex {currentSeries = currentSeries-Thread.currentThread}
+  private def currentSeriesOpt:Option[Series] =
+    inMutex(currentSeries.get(Thread currentThread))
+  private def storeCurrentSeries(series:Series) =
+    inMutex(currentSeries = currentSeries + (Thread.currentThread → series))
+  private def removeCurrentSeries() =
+    inMutex(currentSeries = currentSeries - Thread.currentThread)
 
-  private def offTheRecord[T](doWhat: ⇒T):T = {
+  private def offTheRecord[T](doWhat: ⇒ T):T = {
     val seriesBefore = currentSeriesOpt
-    seriesBefore foreach {f⇒storeCurrentSeries(f withRecordingEnabled false)}
+    seriesBefore foreach {f ⇒ storeCurrentSeries(f withRecordingEnabled false)}
     val result:T = doWhat
     seriesBefore foreach storeCurrentSeries
     result

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/FaultyCallDataSeriesSink.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/FaultyCallDataSeriesSink.scala
@@ -9,17 +9,17 @@ object FaultyCallDataSeriesSink {
     log.warn(s"Possibly faulty series recognized, for $threadLocal, in series no. $seriesNumber:")
     var instructionCounter = 0
     def warn(msg:String) = log warn s"#$seriesNumber/$threadLocal[$instructionCounter] $msg"
-    def warnStackTrace(st:StackTrace) {st.elements foreach {element⇒warn(s"  at $element")}}
+    def warnStackTrace(st:StackTrace) = st.elements foreach {element ⇒ warn(s"  at $element")}
     series foreach {
-      case CallToRemove(_,stackTrace) ⇒
+      case CallToRemove(_, stackTrace) ⇒
         warn("ThreadLocal.remove()")
         warnStackTrace(stackTrace)
         instructionCounter += 1
-      case CallToSet(_,value,stackTrace) ⇒
+      case CallToSet(_, value, stackTrace) ⇒
         warn(s"ThreadLocal.set($value)")
         warnStackTrace(stackTrace)
         instructionCounter += 1
-      case CurrentValueInfo(_,value) ⇒
+      case CurrentValueInfo(_, value) ⇒
         warn(s"Value is now: $value")
         instructionCounter += 1
     }

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/CallData.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/CallData.scala
@@ -2,7 +2,9 @@ package de.metacoder.edwardthreadlocal.analysis.datamodel
 
 import de.metacoder.edwardthreadlocal.analysis.AnalysisSetup
 
-sealed trait CallData {def threadLocal:ThreadLocal[_]}
+sealed trait CallData {
+  def threadLocal:ThreadLocal[_]
+}
 object CallData {
   def forCallToRemove(tl:ThreadLocal[_]):CallToRemove =
     CallToRemove(tl, StackTrace.current())
@@ -11,9 +13,7 @@ object CallData {
   def forCurrentValueInfo(tl:ThreadLocal[_], currentValue:AnyRef)(implicit setup:AnalysisSetup):CurrentValueInfo =
     CurrentValueInfo(tl, setup idOfValue currentValue)
 
-  sealed trait WithStackTrace extends CallData {def stackTrace:StackTrace}
-
-  sealed case class CallToRemove(threadLocal:ThreadLocal[_], stackTrace:StackTrace) extends WithStackTrace
-  sealed case class CallToSet(threadLocal:ThreadLocal[_], valueID:ValueInstanceID, stackTrace:StackTrace) extends WithStackTrace
+  sealed case class CallToRemove(threadLocal:ThreadLocal[_], stackTrace:StackTrace) extends CallData
+  sealed case class CallToSet(threadLocal:ThreadLocal[_], valueID:ValueInstanceID, stackTrace:StackTrace) extends CallData
   sealed case class CurrentValueInfo(threadLocal:ThreadLocal[_], currentValueID:ValueInstanceID) extends CallData
 }

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/StackTrace.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/StackTrace.scala
@@ -8,20 +8,20 @@ object StackTrace {
   private val trivialStackLocalMethodNames = Set("set", "remove")
   def current():StackTrace = {
     def removeInitialStackTraceCall(st:Seq[StackTraceElement]):Seq[StackTraceElement] = st match {
-      case Seq(getStackTraceCall,rst@_*) if getStackTraceCall.getClassName==classOf[Thread].getName ⇒ rst
+      case Seq(getStackTraceCall, rst@_*) if getStackTraceCall.getClassName == classOf[Thread].getName ⇒ rst
       case _ ⇒ st
     }
     def removeInitialEdwardThreadLocalCalls(st:Seq[StackTraceElement]):Seq[StackTraceElement] = st match {
-      case Seq(edwardThreadLocalCall,rst@_*) if edwardThreadLocalCall.getClassName.startsWith(edwardthreadlocal.packageName) ⇒
+      case Seq(edwardThreadLocalCall, rst@_*) if edwardThreadLocalCall.getClassName.startsWith(edwardthreadlocal.packageName) ⇒
         removeInitialEdwardThreadLocalCalls(rst)
       case _ ⇒ st
     }
     def removeInitialTrivialThreadLocalCalls(st:Seq[StackTraceElement]):Seq[StackTraceElement] = st match {
-      case Seq(tlCall,rst@_*) if tlCall.getClassName==classOf[ThreadLocal[_]].getName && trivialStackLocalMethodNames(tlCall getMethodName) ⇒
+      case Seq(tlCall, rst@_*) if tlCall.getClassName == classOf[ThreadLocal[_]].getName && trivialStackLocalMethodNames(tlCall getMethodName) ⇒
         removeInitialTrivialThreadLocalCalls(rst)
       case _ ⇒ st
     }
-    val removeReduntantIntials:Seq[StackTraceElement]⇒Seq[StackTraceElement] =
+    val removeReduntantIntials:Seq[StackTraceElement] ⇒ Seq[StackTraceElement] =
       removeInitialStackTraceCall _ andThen removeInitialEdwardThreadLocalCalls andThen removeInitialTrivialThreadLocalCalls
     StackTrace(removeReduntantIntials(Thread.currentThread().getStackTrace toSeq))
   }

--- a/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/ValueInstanceID.scala
+++ b/agent-impl/src/main/scala/de/metacoder/edwardthreadlocal/analysis/datamodel/ValueInstanceID.scala
@@ -9,8 +9,8 @@ object ValueInstanceID {
   def of(value:AnyRef)(implicit setup:AnalysisSetup):ValueInstanceID = setup idOfValue value
 
   private[analysis] sealed case class ByClassAndSystemIndentityHashCode(clazz:Class[_], systemIdentityHashCode:Int) extends ValueInstanceID {
-    def refersToNull = clazz==null
-    override def toString = if(refersToNull) "null" else s"${clazz getName}@$systemIdentityHashCode"
+    def refersToNull = clazz == null
+    override def toString = if (refersToNull) "null" else s"${clazz getName}@$systemIdentityHashCode"
   }
   private[analysis] object ByClassAndSystemIndentityHashCode {
     def of(v:AnyRef) = v match {


### PR DESCRIPTION
With this change, the IntelliJ IDEA code formatter (with the checked-in settings) can be run over the Agent-Impl Scala files without changing them.
Let's try to keep this up for the future, at last for those files.

In addition to that, I introduced some empty lines between _some_ methods (not the super-trivial ones), to enhance readability.

**Note**: Future code clean-up refactoring pull requests will be based upon this one. (Impossible to separate.)
So I kindly suggest to accept it, if there are no objections.
